### PR TITLE
feat: 全体のレイアウトを追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,10 +24,10 @@ body {
     --primary-foreground: 252 11 17;
     --secondary: 218 35 94;
     --secondary-foreground: 252 11 17;
-    --muted: 210 40% 96.1%;
+    --muted: 214 27 73;
     --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 250 60 92;
+    --accent-foreground: 252 11 17;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
     --border: 214.3 31.8% 91.4%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import Header from "@/components/layouts/header";
+import Footer from "@/components/layouts/footer";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -10,7 +12,7 @@ const inter = Inter({
 export const metadata: Metadata = {
   title: {
     template: "%s | My Tech Blog",
-    default: "ホーム | My Tech Blog",
+    default: "Home | My Tech Blog",
   },
   description: "Web系の技術情報を投稿するブログです。",
 };
@@ -22,8 +24,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${inter.className} antialiased bg-background`}>
-        {children}
+      <body
+        className={`${inter.className} antialiased bg-background min-h-screen grid grid-rows-[auto_1fr_auto]`}
+      >
+        <Header />
+        <main>{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/components/layouts/footer/index.tsx
+++ b/components/layouts/footer/index.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+const Footer = () => {
+  return (
+    <footer className="p-4 border-t border-slate-500">
+      <nav className="flex flex-col items-center text-muted">
+        <Link href="/policy" className="hover:text-primary">
+          Privacy Policy
+        </Link>
+        <small>&copy; {new Date().getFullYear()} by homma koharu</small>
+      </nav>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/components/layouts/header/index.tsx
+++ b/components/layouts/header/index.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { IoLogoGithub } from "react-icons/io";
+
+const navItems = [
+  {
+    label: "Tags",
+    href: "/tags",
+  },
+  {
+    label: "About",
+    href: "/about",
+  },
+  {
+    label: <IoLogoGithub className="size-6" />,
+    href: "https://github.com/khomma0312",
+  },
+];
+
+const Header = () => {
+  return (
+    <header className="flex justify-between items-center w-full h-14 p-5">
+      <a>Logo</a>
+      <nav className="flex gap-4">
+        {navItems.map((item) => (
+          <Link key={item.href} href={item.href} className="hover:text-primary">
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </header>
+  );
+};
+
+export default Header;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18",
+        "react-icons": "^5.3.0",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -3868,6 +3869,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7568,6 +7577,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       }
+    },
+    "react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18",
+    "react-icons": "^5.3.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
## 概要
サイトで共通する、全体のレイアウトを追加した。
ヘッダー、メインコンテンツ、フッターは常に共通したレイアウトになるので`app/layout.tsx`にレイアウトを定義している。

## 画面ショット

### スマホ
<img width="495" alt="スクリーンショット 2024-10-23 6 47 49" src="https://github.com/user-attachments/assets/a6e97d77-f2e7-4459-8334-e892e4208ec4">

### PC
<img width="1404" alt="スクリーンショット 2024-10-23 6 48 24" src="https://github.com/user-attachments/assets/845336a5-3d35-4ba5-8448-d17217afb1ea">
