### PR TITLE
feat: 記事詳細ページのスタイリングとコードハイライト部分のロジック、スタイルを修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "./globals.css";
+import "@/styles/globals.css";
 import Header from "@/components/layouts/header";
 import Footer from "@/components/layouts/footer";
 

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { getPostBySlug } from "@/features/posts/api";
 import { markdownToHtml } from "@/utils/markdown-to-html";
+import "highlight.js/styles/github-dark.css";
+import styles from "@/styles/post.module.css";
 
 type Props = {
   params: {
@@ -15,7 +17,11 @@ const Post = async ({ params }: Props) => {
   // markdownからHTMLに変換
   const content = await markdownToHtml(post.content || "");
 
-  return <article>{content}</article>;
+  return (
+    <div className="mx-auto max-w-prose">
+      <article className={styles.markdown}>{content}</article>
+    </div>
+  );
 };
 
 export default Post;

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -18,7 +18,7 @@ const Post = async ({ params }: Props) => {
   const content = await markdownToHtml(post.content || "");
 
   return (
-    <div className="mx-auto max-w-prose">
+    <div className="mx-auto max-w-[480px] md:max-w-prose py-8">
       <article className={styles.markdown}>{content}</article>
     </div>
   );

--- a/components.json
+++ b/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "config": "tailwind.config.ts",
-    "css": "app/globals.css",
+    "css": "styles/globals.css",
     "baseColor": "slate",
     "cssVariables": true,
     "prefix": ""

--- a/components/layouts/header/index.tsx
+++ b/components/layouts/header/index.tsx
@@ -18,7 +18,7 @@ const navItems = [
 
 const Header = () => {
   return (
-    <header className="flex justify-between items-center w-full h-14 p-5">
+    <header className="sticky top-0 flex justify-between items-center w-full h-14 p-5 border-b border-slate-500 bg-inherit">
       <a>Logo</a>
       <nav className="flex gap-4">
         {navItems.map((item) => (

--- a/lib/marked.ts
+++ b/lib/marked.ts
@@ -1,19 +1,48 @@
 import { Marked } from "marked";
-import { markedHighlight } from "marked-highlight";
 import hljs from "highlight.js";
 
-const marked = new Marked(
-  markedHighlight({
-    emptyLangClass: "hljs",
-    langPrefix: "hljs language-",
-    highlight(code, lang) {
-      const language = hljs.getLanguage(lang) ? lang : "plaintext";
-      return hljs.highlight(code, { language }).value;
-    },
-  }),
-  {
-    gfm: true,
+const escapeTest = /[&<>"']/;
+const escapeReplace = new RegExp(escapeTest.source, "g");
+const escapeReplacements: { [index: string]: string } = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+const getEscapeReplacement = (ch: string) => escapeReplacements[ch];
+
+const escape = (html: string) => {
+  if (escapeTest.test(html)) {
+    return html.replace(escapeReplace, getEscapeReplacement);
   }
-);
+  return html;
+};
+
+const marked = new Marked({
+  gfm: true,
+  renderer: {
+    code({ text, lang }) {
+      const langString = (lang || "").match(/^\S*/)?.[0];
+      const fileInfo = langString ? langString.split(":") : [];
+      const fileName = fileInfo[1] ? fileInfo[1] : "";
+      const language = hljs.getLanguage(fileInfo[0] || "")
+        ? fileInfo[0]
+        : "plaintext";
+
+      const code = text.replace(/\n$/, "") + "\n";
+
+      return (
+        `<pre><span class="codeblock-file-info">${
+          fileName ? fileName : language
+        }</span><code class="hljs language-` +
+        escape(language) +
+        '">' +
+        hljs.highlight(code, { language }).value +
+        "</code></pre>\n"
+      );
+    },
+  },
+});
 
 export default marked;

--- a/lib/marked.ts
+++ b/lib/marked.ts
@@ -1,6 +1,8 @@
 import { Marked } from "marked";
 import hljs from "highlight.js";
 
+// 元々のコードブロックのrendererのロジックは以下参照
+// https://github.com/markedjs/marked/blob/59d5350fdf1b866af749372808ee60f0bf3060d8/src/Renderer.ts#L24
 const escapeTest = /[&<>"']/;
 const escapeReplace = new RegExp(escapeTest.source, "g");
 const escapeReplacements: { [index: string]: string } = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "jsdom": "^25.0.1",
         "lucide-react": "^0.453.0",
         "marked": "^14.1.3",
-        "marked-highlight": "^2.2.0",
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18",
@@ -28,6 +27,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.15",
         "@types/dompurify": "^3.0.5",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^20",
@@ -489,6 +489,34 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.15.tgz",
+      "integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/dompurify": {
@@ -3567,6 +3595,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3606,14 +3646,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/marked-highlight": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.0.tgz",
-      "integrity": "sha512-36LzwtVf7HEbbMITKU4j+iZuyWKgdXJfgYr4F5j27vs79oRPyApuBF3WkS5OsqO1+1lypWxztad7zNRM4qgXFw==",
-      "peerDependencies": {
-        "marked": ">=4 <15"
       }
     },
     "node_modules/merge2": {
@@ -5918,6 +5950,30 @@
         "tslib": "^2.4.0"
       }
     },
+    "@tailwindcss/typography": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.15.tgz",
+      "integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+      "dev": true,
+      "requires": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+          "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        }
+      }
+    },
     "@types/dompurify": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
@@ -8087,6 +8143,18 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -8116,12 +8184,6 @@
       "version": "14.1.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.3.tgz",
       "integrity": "sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g=="
-    },
-    "marked-highlight": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.0.tgz",
-      "integrity": "sha512-36LzwtVf7HEbbMITKU4j+iZuyWKgdXJfgYr4F5j27vs79oRPyApuBF3WkS5OsqO1+1lypWxztad7zNRM4qgXFw==",
-      "requires": {}
     },
     "merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "jsdom": "^25.0.1",
     "lucide-react": "^0.453.0",
     "marked": "^14.1.3",
-    "marked-highlight": "^2.2.0",
     "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18",
@@ -29,6 +28,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.15",
     "@types/dompurify": "^3.0.5",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^20",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,12 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* コードブロックのファイル名の部分 */
+/* この部分はMarkdownからHTMLに変換するため動的に追加しており、Tailwindで直接スタイリングが難しいので例外的にグローバルで指定 */
+.codeblock-file-info {
+  @apply bg-slate-700 block px-2 py-1 w-fit rounded-br-sm;
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;
@@ -39,6 +45,17 @@ body {
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
+
+    --primary-50: 252 22 26;
+    --primary-100: 254 27 31;
+    --primary-200: 254 27 35;
+    --primary-300: 253 25 39;
+    --primary-400: 254 24 44;
+    --primary-500: 255 27 52;
+    --primary-600: 252 95 85;
+    --primary-700: 253 73 81;
+    --primary-800: 253 76  82;
+    --primary-900: 250 60 92;
   }
   .dark {
     --background: 222.2 84% 4.9%;

--- a/styles/post.module.css
+++ b/styles/post.module.css
@@ -1,0 +1,17 @@
+.markdown {
+  /* Base styling */
+  @apply prose prose-invert;
+
+  /* Headings */
+  @apply prose-headings:mb-4 prose-headings:border-b prose-headings:border-slate-700 prose-headings:text-slate-100 prose-headings:font-normal;
+
+  /* Links */
+  @apply prose-a:text-primary prose-a:no-underline prose-a:font-semibold hover:prose-a:text-primary-500;
+
+  /* Code */
+  @apply prose-code:before:content-none prose-code:after:content-none prose-code:bg-slate-900 prose-code:rounded-sm prose-code:p-1;
+  @apply prose-pre:bg-slate-900 prose-pre:p-0;
+
+  /* ul, li */
+  @apply prose-li:marker:text-slate-300;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,16 @@ const config: Config = {
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
+          50: "hsl(var(--primary-50))",
+          100: "hsl(var(--primary-100))",
+          200: "hsl(var(--primary-200))",
+          300: "hsl(var(--primary-300))",
+          400: "hsl(var(--primary-400))",
+          500: "hsl(var(--primary-500))",
+          600: "hsl(var(--primary-600))",
+          700: "hsl(var(--primary-700))",
+          800: "hsl(var(--primary-800))",
+          900: "hsl(var(--primary-900))",
         },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
@@ -58,6 +68,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 };
 export default config;


### PR DESCRIPTION
## 概要
記事詳細ページのスタイリングやコードブロックの表示ロジックを修正。
また、ヘッダーも固定表示するよう修正。

### 修正内容の詳細
- tailwind-typographyの導入
- 記事詳細ページのスタイリング
- コードブロックの表示ロジックをプラグインを使う方法から、markedのrendererに独自ロジックを書く方法に変更
- ヘッダーを固定表示するよう修正
- CSS用のディレクトリ`styles`を追加、グローバルCSSファイルを移動

## 画面ショット

### スマホ
<img width="499" alt="スクリーンショット 2024-10-27 16 00 50" src="https://github.com/user-attachments/assets/5b430136-6265-4d35-9576-3d58fcc7b829">

<img width="498" alt="スクリーンショット 2024-10-27 16 01 04" src="https://github.com/user-attachments/assets/ef45c37f-85a1-49f6-ad7c-dcb0662377fd">

<img width="497" alt="スクリーンショット 2024-10-27 16 01 17" src="https://github.com/user-attachments/assets/6e4f3dc2-5515-4804-b104-b9da4ad50110">


### PC
<img width="1325" alt="スクリーンショット 2024-10-27 16 02 44" src="https://github.com/user-attachments/assets/7fe1e100-dc69-4b1c-a35b-dce9e906b656">

<img width="1323" alt="スクリーンショット 2024-10-27 16 02 52" src="https://github.com/user-attachments/assets/e16456d6-a44a-4e50-b332-6c1cb41fb4d7">

<img width="1323" alt="スクリーンショット 2024-10-27 16 03 00" src="https://github.com/user-attachments/assets/adadbc99-0e18-4095-b455-3d3a66c92ddf">
