### PR TITLE
feat: 記事詳細ページで記事のヘッダー部分（タイトル、日時、タグ）の表示を追加

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,7 +1,12 @@
 import { getPostBySlug } from "@/features/posts/api";
 import { markdownToHtml } from "@/utils/markdown-to-html";
-import "highlight.js/styles/github-dark.css";
-import styles from "@/styles/post.module.css";
+import PostHeader from "@/components/posts/post-header";
+import PostBody from "@/components/posts/post-body";
+
+// TODO: ページの内容に合わせてページのmetadataを作る
+// export const metadata = {};
+
+// TODO: getStaticPropsでページを静的化する
 
 type Props = {
   params: {
@@ -17,9 +22,15 @@ const Post = async ({ params }: Props) => {
   // markdownからHTMLに変換
   const content = await markdownToHtml(post.content || "");
 
+  // markdownのメタデータを取得
+  const { title, date, tags } = post.data;
+
   return (
-    <div className="mx-auto max-w-[480px] md:max-w-prose py-8">
-      <article className={styles.markdown}>{content}</article>
+    <div className="mx-auto max-w-[460px] md:max-w-prose py-8">
+      <article>
+        <PostHeader title={title} date={date} tags={tags} />
+        <PostBody content={content} />
+      </article>
     </div>
   );
 };

--- a/components/posts/post-body/index.tsx
+++ b/components/posts/post-body/index.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+import "highlight.js/styles/github-dark.css";
+import styles from "@/styles/post.module.css";
+
+type Props = {
+  content: string | JSX.Element | JSX.Element[];
+};
+
+const PostBody = ({ content }: Props) => {
+  return <div className={cn(styles.markdown, "py-6")}>{content}</div>;
+};
+
+export default PostBody;

--- a/components/posts/post-header/index.tsx
+++ b/components/posts/post-header/index.tsx
@@ -1,0 +1,30 @@
+import TagLink from "@/components/shared/tag-link";
+
+type Props = {
+  title: string;
+  date: string;
+  tags: string[];
+};
+
+const PostHeader = ({ title, date, tags }: Props) => {
+  return (
+    <div>
+      <h1 className="text-center text-3xl md:text-4xl font-bold py-8">
+        {title}
+      </h1>
+      <div className="flex justify-end pb-12 border-b border-slate-500">
+        <div className="flex flex-col">
+          <span className="text-slate-400 pb-2 text-sm">投稿日時: {date}</span>
+          <div className="flex gap-1 items-center justify-end">
+            <span className="text-slate-400 text-sm">タグ: </span>
+            {tags.map((tag: string) => (
+              <TagLink key={tag} tag={tag} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostHeader;

--- a/components/posts/post-header/index.tsx
+++ b/components/posts/post-header/index.tsx
@@ -3,7 +3,7 @@ import TagLink from "@/components/shared/tag-link";
 type Props = {
   title: string;
   date: string;
-  tags: string[];
+  tags?: string[];
 };
 
 const PostHeader = ({ title, date, tags }: Props) => {
@@ -15,12 +15,14 @@ const PostHeader = ({ title, date, tags }: Props) => {
       <div className="flex justify-end pb-12 border-b border-slate-500">
         <div className="flex flex-col">
           <span className="text-slate-400 pb-2 text-sm">投稿日時: {date}</span>
-          <div className="flex gap-1 items-center justify-end">
-            <span className="text-slate-400 text-sm">タグ: </span>
-            {tags.map((tag: string) => (
-              <TagLink key={tag} tag={tag} />
-            ))}
-          </div>
+          {tags && (
+            <div className="flex gap-1 items-center justify-end">
+              <span className="text-slate-400 text-sm">タグ: </span>
+              {tags.map((tag: string) => (
+                <TagLink key={tag} tag={tag} />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/components/shared/tag-link/index.tsx
+++ b/components/shared/tag-link/index.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+type Props = {
+  tag: string;
+};
+
+const TagLink = ({ tag }: Props) => {
+  return (
+    <Link
+      href={`/posts?tag=${tag}`}
+      className="bg-primary-50/65 border border-slate-600 rounded-md px-1 py-0.5 text-sm hover:bg-primary-50"
+    >
+      {tag}
+    </Link>
+  );
+};
+
+export default TagLink;

--- a/features/posts/api/index.ts
+++ b/features/posts/api/index.ts
@@ -9,5 +9,5 @@ export const getPostBySlug = (slug: string) => {
   const fileContents = readFileSync(path, { encoding: "utf-8" });
   const { data, content } = matter(fileContents);
 
-  return { ...data, slug, content };
+  return { data, slug, content };
 };


### PR DESCRIPTION
## 概要
記事詳細ページで記事のヘッダー部分（タイトル、日時、タグ）の表示を追加した。


## 画面ショット

### スマホ
<img width="498" alt="スクリーンショット 2024-10-28 6 12 23" src="https://github.com/user-attachments/assets/93a35698-585d-4ffe-a27f-4a181df22f2d">


### PC
<img width="1366" alt="スクリーンショット 2024-10-28 6 12 00" src="https://github.com/user-attachments/assets/e7a98590-0582-4325-b7c1-eba187795e6b">
