### PR TITLE
fix: 記事詳細ページのHTML構造を修正、記事の最下部に一覧へ戻るセクションを追加

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { getPostBySlug } from "@/features/posts/api";
 import { markdownToHtml } from "@/utils/markdown-to-html";
 import PostHeader from "@/components/posts/post-header";
 import PostBody from "@/components/posts/post-body";
+import Divider from "@/components/shared/divider";
+import PostFooter from "@/components/posts/post-footer";
 
 // TODO: ページの内容に合わせてページのmetadataを作る
 // export const metadata = {};
@@ -29,7 +31,10 @@ const Post = async ({ params }: Props) => {
     <div className="mx-auto max-w-[460px] md:max-w-prose py-8">
       <article>
         <PostHeader title={title} date={date} tags={tags} />
+        <Divider />
         <PostBody content={content} />
+        <Divider />
+        <PostFooter />
       </article>
     </div>
   );

--- a/components/posts/post-body/index.tsx
+++ b/components/posts/post-body/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 const PostBody = ({ content }: Props) => {
-  return <div className={cn(styles.markdown, "py-6")}>{content}</div>;
+  return <div className={cn(styles.markdown, "py-2")}>{content}</div>;
 };
 
 export default PostBody;

--- a/components/posts/post-footer/index.tsx
+++ b/components/posts/post-footer/index.tsx
@@ -3,7 +3,10 @@ import Link from "next/link";
 const PostFooter = () => {
   return (
     <section className="py-10">
-      <Link href="/" className="text-primary hover:text-primary-500 text-sm">
+      <Link
+        href="/posts"
+        className="text-primary hover:text-primary-500 text-sm"
+      >
         &lt; 記事一覧に戻る
       </Link>
     </section>

--- a/components/posts/post-footer/index.tsx
+++ b/components/posts/post-footer/index.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+const PostFooter = () => {
+  return (
+    <section className="py-10">
+      <Link href="/" className="text-primary hover:text-primary-500 text-sm">
+        &lt; 記事一覧に戻る
+      </Link>
+    </section>
+  );
+};
+
+export default PostFooter;

--- a/components/posts/post-header/index.tsx
+++ b/components/posts/post-header/index.tsx
@@ -8,11 +8,11 @@ type Props = {
 
 const PostHeader = ({ title, date, tags }: Props) => {
   return (
-    <div>
+    <div className="pb-12">
       <h1 className="text-center text-3xl md:text-4xl font-bold py-8">
         {title}
       </h1>
-      <div className="flex justify-end pb-12 border-b border-slate-500">
+      <div className="flex justify-end">
         <div className="flex flex-col">
           <span className="text-slate-400 pb-2 text-sm">投稿日時: {date}</span>
           {tags && (

--- a/components/shared/divider/index.tsx
+++ b/components/shared/divider/index.tsx
@@ -1,0 +1,5 @@
+const Divider = () => {
+  return <hr className="h-[1px] border-slate-600 my-6" />;
+};
+
+export default Divider;


### PR DESCRIPTION
## 概要
- 記事詳細ページのHTML構造を修正（区切り線を`hr`に変更、記事内のヘッダーや本文などを`section`で分けるよう変更）
- 記事の最下部に一覧へ戻るセクションを追加

## 画面ショット

### スマホ
<img width="498" alt="スクリーンショット 2024-10-28 7 03 43" src="https://github.com/user-attachments/assets/76eaa2e1-81d7-41b4-9bdb-82d36c93b203">

<img width="494" alt="スクリーンショット 2024-10-28 7 03 51" src="https://github.com/user-attachments/assets/c44a92ca-e02a-4a0e-ad5c-fa149587a4ee">

### PC

<img width="1394" alt="スクリーンショット 2024-10-28 7 05 42" src="https://github.com/user-attachments/assets/3cdea507-4afc-4865-aac1-ddc47e395ca2">

<img width="1394" alt="スクリーンショット 2024-10-28 7 05 50" src="https://github.com/user-attachments/assets/2754b6cb-d3b9-43f8-9c14-fe86308ddb2b">
