### PR TITLE
feat: リンクをリンクカード、YouTube埋め込み、X埋め込みに変換するよう修正

### DIFF
--- a/app/posts/[slug]/layout.tsx
+++ b/app/posts/[slug]/layout.tsx
@@ -1,0 +1,18 @@
+import Script from "next/script";
+
+export default function PostLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      {children}
+      <Script
+        id="twitter-embed-script"
+        src="https://platform.twitter.com/widgets.js"
+        strategy="beforeInteractive"
+      />
+    </>
+  );
+}

--- a/components/posts/link-card/index.tsx
+++ b/components/posts/link-card/index.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { cn, getOgpDataFromUrl } from "@/lib/utils";
+
+type Props = {
+  href: string;
+};
+
+const LinkCard = async ({ href }: Props) => {
+  const { title, description, image } = await getOgpDataFromUrl(href);
+  const domain = new URL(href).hostname;
+
+  return (
+    <div className="not-prose bg-background border border-primary-200 my-3 rounded-sm md:my-5 md:rounded-md hover:bg-neutral-50/10">
+      <Link
+        href={href}
+        className="grid grid-cols-[1fr_220px] md:grid-cols-[1fr_280px]"
+        target="_blank"
+      >
+        <div
+          className={cn(
+            "p-3 grid",
+            description ? "grid-rows-[1.5fr_2fr_1fr]" : "grid-rows-[1.5fr_1fr]"
+          )}
+        >
+          <div className="font-semibold text-sm md:text-base">
+            <p className="line-clamp-1">{title ? title : href}</p>
+          </div>
+          {description && (
+            <div className="text-xs md:text-sm text-slate-400">
+              <span className="line-clamp-2">{description}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-1 text-xs md:text-sm">
+            <img src={`https://www.google.com/s2/favicons?domain=${domain}`} />
+            <span>{domain}</span>
+          </div>
+        </div>
+        {image && (
+          <div>
+            <img
+              src={image}
+              alt=""
+              className="max-w-full rounded-tr-md rounded-br-md"
+            />
+          </div>
+        )}
+      </Link>
+    </div>
+  );
+};
+
+export default LinkCard;

--- a/components/posts/link-card/index.tsx
+++ b/components/posts/link-card/index.tsx
@@ -2,17 +2,17 @@ import Link from "next/link";
 import { cn, getOgpDataFromUrl } from "@/lib/utils";
 
 type Props = {
-  href: string;
+  url: string;
 };
 
-const LinkCard = async ({ href }: Props) => {
-  const { title, description, image } = await getOgpDataFromUrl(href);
-  const domain = new URL(href).hostname;
+const LinkCard = async ({ url }: Props) => {
+  const { title, description, image } = await getOgpDataFromUrl(url);
+  const domain = new URL(url).hostname;
 
   return (
     <div className="not-prose bg-background border border-primary-200 my-3 rounded-sm md:my-5 md:rounded-md hover:bg-neutral-50/10">
       <Link
-        href={href}
+        href={url}
         className="grid grid-cols-[1fr_220px] md:grid-cols-[1fr_280px]"
         target="_blank"
       >
@@ -23,7 +23,7 @@ const LinkCard = async ({ href }: Props) => {
           )}
         >
           <div className="font-semibold text-sm md:text-base">
-            <p className="line-clamp-1">{title ? title : href}</p>
+            <p className="line-clamp-1">{title ? title : url}</p>
           </div>
           {description && (
             <div className="text-xs md:text-sm text-slate-400">

--- a/components/posts/x-link-card/index.tsx
+++ b/components/posts/x-link-card/index.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type Props = {
+  url: string;
+  options?: {
+    cards?: "hidden";
+    theme?: "dark" | "light";
+    width?: number;
+  };
+};
+
+const XLinkCard = (props: Props) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const key = JSON.stringify(props);
+  const { url, options } = props;
+  // twitter.comでないとembedに変換されないので文字列を置換
+  const twitterUrl = url.replace("x.com", "twitter.com");
+
+  useEffect(() => {
+    if (rootRef.current) {
+      window.twttr?.widgets.load(rootRef.current);
+    }
+  }, [key]);
+
+  return (
+    <div ref={rootRef} key={key}>
+      <blockquote
+        className="twitter-tweet"
+        data-cards={options?.cards}
+        data-theme={options?.theme}
+        data-width={options?.width}
+      >
+        <a href={twitterUrl}>{twitterUrl}</a>
+      </blockquote>
+    </div>
+  );
+};
+
+export default XLinkCard;

--- a/components/posts/youtube-embed/index.tsx
+++ b/components/posts/youtube-embed/index.tsx
@@ -1,0 +1,22 @@
+type Props = {
+  href: string;
+};
+
+const YouTubeEmbed = async ({ href }: Props) => {
+  const matches = href.match(/^(?:https?:\/\/)?(?:www\.)?([^\/]+)\/?(.*)/i);
+  const path = matches ? matches[2] : "";
+  const videoId = path.replace("watch?v=", "");
+
+  return (
+    <iframe
+      src={`https://www.youtube.com/embed/${videoId}`}
+      title="YouTube video player"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      referrerPolicy="strict-origin-when-cross-origin"
+      allowFullScreen
+      className="w-full h-full aspect-video my-3 md:my-5"
+    ></iframe>
+  );
+};
+
+export default YouTubeEmbed;

--- a/components/posts/youtube-embed/index.tsx
+++ b/components/posts/youtube-embed/index.tsx
@@ -14,7 +14,7 @@ const YouTubeEmbed = async ({ url }: Props) => {
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       referrerPolicy="strict-origin-when-cross-origin"
       allowFullScreen
-      className="w-full h-full aspect-video my-3 md:my-5"
+      className="w-full h-full aspect-video my-3 md:px-5 md:my-5"
     ></iframe>
   );
 };

--- a/components/posts/youtube-embed/index.tsx
+++ b/components/posts/youtube-embed/index.tsx
@@ -1,9 +1,9 @@
 type Props = {
-  href: string;
+  url: string;
 };
 
-const YouTubeEmbed = async ({ href }: Props) => {
-  const matches = href.match(/^(?:https?:\/\/)?(?:www\.)?([^\/]+)\/?(.*)/i);
+const YouTubeEmbed = async ({ url }: Props) => {
+  const matches = url.match(/^(?:https?:\/\/)?(?:www\.)?([^\/]+)\/?(.*)/i);
   const path = matches ? matches[2] : "";
   const videoId = path.replace("watch?v=", "");
 

--- a/components/zenn/zenn-card.tsx
+++ b/components/zenn/zenn-card.tsx
@@ -13,7 +13,7 @@ type Props = {
 const ZennCard = ({ post }: Props) => {
   return (
     <Card className="border-primary-100 rounded-lg relative w-full h-full">
-      <Link href={post.url}>
+      <Link href={post.url} target="_blank">
         <Image
           width={1200}
           height={630}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { JSDOM } from "jsdom";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -21,21 +22,35 @@ export const extractOgpDataFromHead = (head: HTMLHeadElement) => {
       )
       // 必要なOGPデータをオブジェクトにまとめる
       .reduce((acc, cur) => {
+        const content = cur.getAttribute("content");
+
         if (cur.getAttribute("property") === "og:title") {
-          const content = cur.getAttribute("content");
           return { ...acc, title: content || "" };
         }
 
         if (cur.getAttribute("property") === "og:image") {
-          const content = cur.getAttribute("content");
           return { ...acc, image: content || "" };
         }
 
         if (cur.getAttribute("property") === "og:url") {
-          const content = cur.getAttribute("content");
           return { ...acc, url: content || "" };
         }
+
+        if (cur.getAttribute("property") === "og:description") {
+          return { ...acc, description: content || "" };
+        }
         return acc;
-      }, {} as { title: string; image: string; url: string })
+      }, {} as { title: string; image: string; url: string; description: string })
   );
+};
+
+export const getOgpDataFromUrl = async (url: string) => {
+  const html = await fetch(url).then((res) => res.text());
+  // HTML文字列を解析し、headタグ要素を取得
+  const { document } = new JSDOM(html).window;
+  const { head } = document;
+  // headタグ内から必要なOGPデータを取得
+  const ogpData = extractOgpDataFromHead(head);
+
+  return ogpData;
 };

--- a/types/global-variables.ts
+++ b/types/global-variables.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    twttr: {
+      widgets: {
+        load: (element?: HTMLElement) => void;
+      };
+    };
+  }
+}
+
+export {};

--- a/utils/convertLinkToCard.tsx
+++ b/utils/convertLinkToCard.tsx
@@ -8,7 +8,10 @@ export const convertLinkToCard = (href: string) => {
   const domain = matches ? matches[1] : "";
   const path = matches ? matches[2] : "";
 
-  if (["youtube.com"].includes(domain) && path.startsWith("watch")) {
+  if (
+    (domain === "youtube.com" && path.startsWith("watch")) ||
+    domain === "youtu.be"
+  ) {
     return <YouTubeEmbed url={href} />;
   }
 

--- a/utils/convertLinkToCard.tsx
+++ b/utils/convertLinkToCard.tsx
@@ -1,4 +1,5 @@
 import YouTubeEmbed from "@/components/posts/youtube-embed";
+import XLinkCard from "@/components/posts/x-link-card";
 import LinkCard from "@/components/posts/link-card";
 
 export const convertLinkToCard = (href: string) => {
@@ -7,18 +8,13 @@ export const convertLinkToCard = (href: string) => {
   const domain = matches ? matches[1] : "";
   const path = matches ? matches[2] : "";
 
-  console.log(matches);
-
-  switch (domain) {
-    case "youtube.com":
-      return path.startsWith("watch") ? (
-        <YouTubeEmbed href={href} />
-      ) : (
-        <LinkCard href={href} />
-      );
-    // case "x.com":
-    //   return <XLinkCard href={href} />;
-    default:
-      return <LinkCard href={href} />;
+  if (["youtube.com"].includes(domain) && path.startsWith("watch")) {
+    return <YouTubeEmbed url={href} />;
   }
+
+  if (["x.com", "twitter.com"].includes(domain) && path.includes("status")) {
+    return <XLinkCard url={href} options={{ theme: "dark" }} />;
+  }
+
+  return <LinkCard url={href} />;
 };

--- a/utils/convertLinkToCard.tsx
+++ b/utils/convertLinkToCard.tsx
@@ -1,0 +1,24 @@
+import YouTubeEmbed from "@/components/posts/youtube-embed";
+import LinkCard from "@/components/posts/link-card";
+
+export const convertLinkToCard = (href: string) => {
+  // YouTubeか、Twitterか、普通のリンクかでコンポーネントを出し分ける(正規表現とかで判定)
+  const matches = href.match(/^(?:https?:\/\/)?(?:www\.)?([^\/]+)\/?(.*)/i);
+  const domain = matches ? matches[1] : "";
+  const path = matches ? matches[2] : "";
+
+  console.log(matches);
+
+  switch (domain) {
+    case "youtube.com":
+      return path.startsWith("watch") ? (
+        <YouTubeEmbed href={href} />
+      ) : (
+        <LinkCard href={href} />
+      );
+    // case "x.com":
+    //   return <XLinkCard href={href} />;
+    default:
+      return <LinkCard href={href} />;
+  }
+};

--- a/utils/markdown-to-html.ts
+++ b/utils/markdown-to-html.ts
@@ -1,7 +1,8 @@
 import marked from "@/lib/marked";
 import DOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
-import parse from "html-react-parser";
+import parse, { Element } from "html-react-parser";
+import { convertLinkToCard } from "./convertLinkToCard";
 
 export const markdownToHtml = async (content: string) => {
   const html = await marked.parse(content || "");
@@ -10,5 +11,20 @@ export const markdownToHtml = async (content: string) => {
   const purify = DOMPurify(window);
   const sanitizedHtml = purify.sanitize(html);
 
-  return parse(sanitizedHtml);
+  return parse(sanitizedHtml, {
+    replace(domNode) {
+      // ブロックレベルのリンクのみカード化するため、pタグの要素を取得
+      if (domNode instanceof Element && domNode.name === "p") {
+        const linkNode = domNode.children[0] as Element;
+        // aタグかつ、文字にリンクを貼っていない(hrefとタグ内のテキストが同じ)場合のみ取得
+        if (
+          linkNode.name === "a" &&
+          "data" in linkNode.children[0] &&
+          linkNode.children[0].data === linkNode.attribs.href
+        ) {
+          return convertLinkToCard(linkNode.attribs.href);
+        }
+      }
+    },
+  });
 };


### PR DESCRIPTION
## 概要
リンクカード、YouTube埋め込み、X埋め込みに対応できるよう実装を追加。

## 画面ショット

### スマホ
<img width="495" alt="スクリーンショット 2024-11-15 6 55 52" src="https://github.com/user-attachments/assets/4245c086-905f-4a07-80d9-db317e1010d0">


### PC
<img width="1333" alt="スクリーンショット 2024-11-15 7 02 38" src="https://github.com/user-attachments/assets/0e8bad2d-60a5-4739-9cb0-4ecc310744bf">


<img width="1375" alt="スクリーンショット 2024-11-15 6 56 42" src="https://github.com/user-attachments/assets/54c9b180-4c67-4b5c-80f0-a4279ce42774">
